### PR TITLE
Fix incompatibility with EE 2.9.3 and potential changes to the "Label" column

### DIFF
--- a/linktracker.js
+++ b/linktracker.js
@@ -63,7 +63,7 @@ function recordClick(e)
 	if (source.nodeType == 3)
 		source = source.parentNode;
 		
-	var id, target, URL, label
+	var id, target, URL, label;
 	
 	if( source.tagName == "IMG" )
 	{
@@ -76,7 +76,7 @@ function recordClick(e)
 	}else{
 		id = source.getAttribute('id');
 		target = source.getAttribute('href');		
-		label = escape(source.childNodes[0].nodeValue);
+		label = source.getAttribute('rel');
 	}
 	url = document.location.href;
 	//---------------------------------

--- a/system/expressionengine/third_party/linktracker/mcp.linktracker.php
+++ b/system/expressionengine/third_party/linktracker/mcp.linktracker.php
@@ -68,8 +68,9 @@ class Linktracker_mcp {
     /** -------------------------*/
     
     public function index()
-    {              
-        $this->EE->cp->set_variable('cp_page_title', $this->EE->lang->line('linktracker_module_name'));
+    {       
+
+        $this->EE->view->cp_page_title = $this->EE->lang->line('linktracker_module_name');
 
 		$vars = array(); $clicks = array(); $label = array();
 
@@ -105,7 +106,8 @@ class Linktracker_mcp {
 	
 	function reset() {
 
-		$this->EE->cp->set_variable('cp_page_title', $this->EE->lang->line('linktracker_reset'));
+		$this->EE->view->cp_page_title = $this->EE->lang->line('linktracker_reset');
+
 	 	$this->EE->cp->set_breadcrumb($this->base, $this->EE->lang->line('linktracker_module_name'));
 	 	
  		$id = $this->EE->input->get('link_id');
@@ -125,7 +127,8 @@ class Linktracker_mcp {
 	 	
 	 	$id = $this->EE->input->get('link_id');
 
-	 	$this->EE->cp->set_variable('cp_page_title', $this->EE->lang->line('linktracker_link_detail'));
+	 	$this->EE->view->cp_page_title = $this->EE->lang->line('linktracker_link_detail');
+	 	
 	 	$this->EE->cp->set_breadcrumb($this->base, $this->EE->lang->line('linktracker_module_name'));
 
     	$vars = array(); $clicks = array();


### PR DESCRIPTION
Problem with "Cp::set_variable()" resolved.

Column "Label" gets his data from the attribute "rel" when "<a>" tag is the "source"